### PR TITLE
UI Added TableActions on all components, enhanced BlockUI style, fix Runtime forceDevScan declaration

### DIFF
--- a/src/app/common/blockui/blockui-service.ts
+++ b/src/app/common/blockui/blockui-service.ts
@@ -1,6 +1,6 @@
 import { Injectable, ApplicationRef, ViewContainerRef, Component, ComponentRef, ComponentFactoryResolver, ComponentFactory, ViewChild } from '@angular/core';
 
-import { BlockUIComponent } from './blockui-component'; // error here, wrong path
+import { BlockUIComponent } from './blockui-component';
 
 
 @Injectable()
@@ -10,9 +10,8 @@ export class BlockUIService {
     constructor(private _appRef: ApplicationRef, private _resolver: ComponentFactoryResolver) {
     }
 
-    public start(placeholder, prop) { // placeholder missing!
-        //let elementRef: ViewContainerRef = (<any>this._appRef)['_rootComponents'][0].location; // remove this
-        let elementRef = placeholder; // add this
+    public start(placeholder, prop) {
+        let elementRef = placeholder;
         return this.startInside(elementRef, null, prop);
     }
 

--- a/src/app/common/blockui/blockui.css
+++ b/src/app/common/blockui/blockui.css
@@ -1,13 +1,14 @@
 .block-overlay {
-  background-color: rgba(255, 255, 255, 0.7);
+  background-color:#2E6DA4;
   cursor: wait;
 }
 .block-message-container {
-  position: absolute;
-  top: 35%;
+  position: fixed;
+  background-color: white;
+  top: 30%;
   left: 0;
   right: 0;
-  height: 0;
+  height: 100px;
   text-align: center;
   z-index: 10001;
   cursor: wait;

--- a/src/app/common/table-actions.ts
+++ b/src/app/common/table-actions.ts
@@ -43,10 +43,15 @@ import { FormsModule, NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/f
         <select *ngIf="selectorSelected.type === 'boolean'" class="select-pages" style="width:auto" [(ngModel)]="propertySelected">
           <option *ngFor="let option of selectorSelected.options" [ngValue]="option" (ngModelChange)="changeProperty($event)">{{option}}</option>
         </select>
-        <ss-multiselect-dropdown *ngIf="selectorSelected.type === 'multiselector'" [options]="selectorSelected.options" [texts]="myTexts" [settings]="mySettingsInflux" [(ngModel)]="propertySelected"></ss-multiselect-dropdown>
-        <div [formGroup]="selectorSelected.options" *ngIf="selectorSelected.type === 'input'" style="border:none; display:inline">
+        <ss-multiselect-dropdown *ngIf="selectorSelected.type === 'multiselector'" [options]="selectorSelected.options" [(ngModel)]="propertySelected"></ss-multiselect-dropdown>
+        <ss-multiselect-dropdown *ngIf="selectorSelected.type === 'single-multiselector'" [options]="selectorSelected.options" [settings]="{'singleSelect': true}" [(ngModel)]="propertySelected"></ss-multiselect-dropdown>        <div [formGroup]="selectorSelected.options" *ngIf="selectorSelected.type === 'input'" style="border:none; display:inline">
               <input formControlName="formControl" id="formControl" [(ngModel)]="propertySelected" style="width:auto"/>
               <control-messages style="display:block; margin-top:5px" [control]="selectorSelected.options.controls.formControl" ></control-messages>
+        </div>
+        <div [formGroup]="selectorSelected.options" *ngIf="selectorSelected.type === 'input-password'" style="border:none; display:inline">
+        <input #inputPassword formControlName="formControl" id="formControl" [(ngModel)]="propertySelected" type="password" style="width:auto"/>
+        <i style="margin-left:-25px; margin-right:6px" [ngClass]="inputPassword.type === 'password' ? ['glyphicon glyphicon-eye-open text-primary'] : ['glyphicon glyphicon-eye-close text-primary']" passwordToggle [input]="inputPassword"> </i>
+        <control-messages style="display:block; margin-top:5px" [control]="selectorSelected.options.controls.formControl" ></control-messages>
         </div>
       </div>
       <div class="col-md-1" *ngIf="propertySelected">

--- a/src/app/common/table-available-actions.ts
+++ b/src/app/common/table-available-actions.ts
@@ -1,102 +1,244 @@
-import { FormBuilder, Validators, FormArray, FormGroup, FormControl} from '@angular/forms';
+import { FormBuilder, Validators, FormArray, FormGroup, FormControl } from '@angular/forms';
 import { ValidationService } from './custom-validation/validation.service'
 
 export class AvailableTableActions {
 
   //AvailableOptions result depeding on component type
-  public availableOptions : Array<any>;
+  public availableOptions: Array<any>;
 
   // type can be : device,...
   // data is the passed extraData when declaring AvailableTableActions on each component
-  checkComponentType(type, data?) : any {
+  checkComponentType(type, data?): any {
     switch (type) {
-      case 'kapacitor-component':
-        return this.getKapacitorAvailableActions();
-        case 'alert-component':
-        return this.getAlertAvailableActions();
-        case 'devicestats-component':
-        return this.getDeviceStatsAvailableActions();
-        case 'outhttp-component':
-        return this.getOutHTTPAvailableActions();
-        case 'product-component':
-        return this.getProductAvailableActions();
-        case 'rangetime-component':
-        return this.getRangeTimeAvailableActions();
-        case 'template-component':
-        return this.getTemplateAvailableActions();
+      case 'influxcfg':
+        return this.getInfluxAvailableActions();
+      case 'hmcservercfg':
+        return this.getHMCServerAvailableActions(data);
+      case 'devicecfg':
+        return this.getDeviceAvailableActions(data);
       default:
         return null;
-      }
+    }
   }
 
-  constructor (componentType : string, extraData? : any) {
+  constructor(componentType: string, extraData?: any) {
+    console.log(extraData);
     this.availableOptions = this.checkComponentType(componentType, extraData);
   }
 
-  getKapacitorAvailableActions (data ? : any) : any {
+  getInfluxAvailableActions(data?: any): any {
     let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
+      //Remove Action
+      {
+        'title': 'Remove', 'content':
+          { 'type': 'button', 'action': 'RemoveAllSelected' }
+      },
+      //Change Property Action
+      {
+        'title': 'Change property', 'content':
+          {
+            'type': 'selector', 'action': 'ChangeProperty', 'options': [
+              {
+                'title': 'Precision', 'type': 'boolean', 'options': [
+                  'h', 'm', 's', 'ms', 'u', 'ns']
+              },
+              {
+                'title': 'Retention', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title': 'Timeout', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator]))
+                  })
+              }
+            ]
+          },
       }
     ];
     return tableAvailableActions;
   }
 
-  getAlertAvailableActions (data ? : any) : any {
+  getHMCServerAvailableActions(data?: any): any {
     let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
+      //Remove Action
+      {
+        'title': 'Remove', 'content':
+          { 'type': 'button', 'action': 'RemoveAllSelected' }
+      },
+      //Change Property Action
+      {
+        'title': 'Change property', 'content':
+          {
+            'type': 'selector', 'action': 'ChangeProperty', 'options': [
+              {
+                'title': 'Active', 'type': 'boolean', 'options': [
+                  'true', 'false'
+                ]
+              },
+              {
+                'title': 'LogLevel', 'type': 'boolean', 'options': [
+                  'panic', 'fatal', 'error', 'warning', 'info', 'debug'
+                ]
+              },
+              {
+                'title': 'ManagedSystemsOnly', 'type': 'boolean', 'options': [
+                  'true', 'false'
+                ]
+              },
+              {
+                'title': 'Freq', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator]))
+                  })
+              },
+              {
+                'title': 'UpdateScanFreq', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator]))
+                  })
+              },
+              {
+                'title': 'UpdateFltFreq', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerAndLessOneValidator]))
+                  })
+              },
+              {
+                'title': 'DeviceTagValue', 'type': 'boolean', 'options': [
+                  'id', 'host'
+                ]
+              },
+              {
+                'title': 'DeviceTagName', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title' : 'OutDB', 'type':'single-multiselector', 'options' :
+                data
+              },
+              {
+                'title': 'User', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title': 'Password', 'type': 'input-password', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title': 'ExtraTags', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags]))
+                  })
+              }
+            ]
+          },
+      },
+      //AppendProperty
+      {
+        'title': 'AppendProperty', 'content':
+          {
+            'type': 'selector', 'action': 'AppendProperty', 'options': [
+             {
+                'title': 'ExtraTags', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags]))
+                  })
+              }
+            ]
+          }
       }
     ];
     return tableAvailableActions;
   }
 
-  getDeviceStatsAvailableActions (data ? : any) : any {
-    let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
-      }
-    ];
-    return tableAvailableActions;
-  }
-  getOutHTTPAvailableActions (data ? : any) : any {
-    let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
-      }
-    ];
-    return tableAvailableActions;
-  }
-  getProductAvailableActions (data ? : any) : any {
-    let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
-      }
-    ];
-    return tableAvailableActions;
-  }
-  getRangeTimeAvailableActions (data ? : any) : any {
-    let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
-      }
-    ];
-    return tableAvailableActions;
-  }
-  getTemplateAvailableActions (data ? : any) : any {
-    let tableAvailableActions = [
-    //Remove Action
-      {'title': 'Remove', 'content' :
-        {'type' : 'button','action' : 'RemoveAllSelected'}
-      }
-    ];
-    return tableAvailableActions;
-  }
 
+  getDeviceAvailableActions(data?: any): any {
+    let tableAvailableActions = [
+      //Remove Action
+      {
+        'title': 'Remove', 'content':
+          { 'type': 'button', 'action': 'RemoveAllSelected' }
+      },
+      //Change Property Action
+      {
+        'title': 'Change property', 'content':
+          {
+            'type': 'selector', 'action': 'ChangeProperty', 'options': [
+              {
+                'title': 'EnableHMCStats', 'type': 'boolean', 'options': [
+                  'true', 'false'
+                ]
+              },
+              {
+                'title': 'EnableNmonStats', 'type': 'boolean', 'options': [
+                  'true', 'false'
+                ]
+              },
+              {
+                'title': 'NmonLogLevel', 'type': 'boolean', 'options': [
+                  'panic', 'fatal', 'error', 'warning', 'info', 'debug'
+                ]
+              },
+              {
+                'title': 'NmonProtDebug', 'type': 'boolean', 'options': [
+                  'panic', 'fatal', 'error', 'warning', 'info', 'debug'
+                ]
+              },
+              {
+                'title': 'NmonFreq', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator]))
+                  })
+              },
+              {
+                'title' : 'NmonOutDB', 'type':'single-multiselector', 'options' :
+                data
+              },
+              {
+                'title': 'NmonSSHUser', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title': 'NmonSSHKey', 'type': 'input-password', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.required)
+                  })
+              },
+              {
+                'title': 'ExtraTags', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags]))
+                  })
+              }
+            ]
+          },
+      },
+      //AppendProperty
+      {
+        'title': 'AppendProperty', 'content':
+          {
+            'type': 'selector', 'action': 'AppendProperty', 'options': [
+             {
+                'title': 'ExtraTags', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('', Validators.compose([ValidationService.noWhiteSpaces, ValidationService.extraTags]))
+                  })
+              }
+            ]
+          }
+      }
+    ];
+    return tableAvailableActions;
+  }
 }

--- a/src/app/device/devicecfg.component.ts
+++ b/src/app/device/devicecfg.component.ts
@@ -94,7 +94,7 @@ export class DeviceCfgComponent {
       EnableHMCStats: [this.deviceForm ? this.deviceForm.value.EnableHMCStats : 'true', Validators.required],
       EnableNmonStats: [this.deviceForm ? this.deviceForm.value.EnableNmonStats : 'true', Validators.required],
       NmonFreq: [this.deviceForm ? this.deviceForm.value.NmonFreq : 60,  ValidationService.uintegerNotZeroValidator],
-      NmonOutDB: [this.deviceForm ? this.deviceForm.value.NmonOutDB: ''],
+      NmonOutDB: [this.deviceForm ? this.deviceForm.value.NmonOutDB : '', Validators.required],
       NmonIP: [this.deviceForm ? this.deviceForm.value.NmonIP : ''],
       NmonSSHUser: [this.deviceForm ? this.deviceForm.value.NmonSSHUser : ''],
       NmonSSHKey: [this.deviceForm ? this.deviceForm.value.NmonSSHKey : ''],
@@ -164,8 +164,22 @@ export class DeviceCfgComponent {
       case 'tableaction':
         this.applyAction(action.event, action.data);
       break;
+      case 'editenabled':
+        this.enableEdit();
+      break;
     }
   }
+
+  enableEdit() {
+    this.influxServerService.getInfluxServer(null)
+      .subscribe(
+        data => {
+          this.tableAvailableActions = new AvailableTableActions(this.defaultConfig['slug'],this.createMultiselectArray(data,'ID','ID','Description')).availableOptions
+        },
+        err => console.log(err),
+        () => console.log()
+      );
+    }
 
   viewItem(id) {
     console.log('view', id);
@@ -300,7 +314,7 @@ export class DeviceCfgComponent {
         }
       }
     } else {
-      return this.deviceCfgService.editDeviceCfg(component, component.ID)
+      return this.deviceCfgService.editDeviceCfg(component, component.ID,true)
       .do(
         (test) =>  { this.counterItems++ },
         (err) => { this.counterErrors.push({'ID': component['ID'], 'error' : err['_body']})}

--- a/src/app/device/devicecfg.data.ts
+++ b/src/app/device/devicecfg.data.ts
@@ -6,10 +6,12 @@ export const DeviceCfgComponentConfig: any =
       { title: 'Dev  Name', name: 'Name' },
       { title: 'Serial Number', name: 'SerialNumber' },
       { title: 'OS Version',name:'OSVersion'},
-      { title: 'type', name: 'Type' },
+      { title: 'Device Type', name: 'Type' },
       { title: 'Location', name: 'Location' },
-      { title: 'Enable HMC stats', name: 'EnableHMCStats' },
+      { title: 'Enable HMC Stats', name: 'EnableHMCStats' },
       { title: 'Enable Nmon Stats', name: 'EnableNmonStats' },
+      { title: 'NmonOutDB', name: 'NmonOutDB' },
+      { title: 'NmonSSHUser', name: 'NmonSSHUser' },
       { title: 'ExtraTags', name: 'ExtraTags' }
     ],
     'slug' : 'devicecfg'

--- a/src/app/device/deviceeditor.html
+++ b/src/app/device/deviceeditor.html
@@ -7,7 +7,7 @@
     </test-modal>
     <!--export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal-->
     <table-list #listTableComponent [typeComponent]="defaultConfig['slug']" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting" [tableRole]="tableRole"
-    [sanitizeCell]="cellParser" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
+    [sanitizeCell]="cellParser" [roleActions]="overrideRoleActions" overrideEditEnabled="true" [tableAvailableActions]="tableAvailableActions" (customClicked)="customActions($event)"></table-list>
   </ng-template>
   <ng-template ngSwitchDefault>
     <form [formGroup]="deviceForm" class="form-horizontal" (ngSubmit)="editmode === 'create' ? saveDeviceCfg() : updateDeviceCfg()">

--- a/src/app/hmcserver/hmcserver.component.html
+++ b/src/app/hmcserver/hmcserver.component.html
@@ -1,12 +1,13 @@
 <h2>{{defaultConfig.name}}</h2>
+<div #blocker style="position: absolute; top: 50%;"></div>
 <ng-container [ngSwitch]="editmode">
   <ng-template ngSwitchCase="list">
     <test-modal #viewModal [titleName]="defaultConfig.name"></test-modal>
     <test-modal #viewModalDelete titleName='Deleting:' [customMessage]="['Deleting this OutHTTP Wrapper will affect the following components','Deleting this OutHTTP Wrapper will NOT affect any component. Safe delete']" [customMessageClass]="['alert alert-danger','alert alert-success']"
         [showValidation]="true" [textValidation]="'Delete'" [controlSize]="true" (validationClicked)="deleteSampleItem($event)">
     </test-modal>
-    <table-list #listTableComponent [typeComponent]="'outhttp-component'" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting"
-        [tableRole]="tableRole" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
+    <table-list #listTableComponent [typeComponent]="defaultConfig['slug']" [data]="data" [columns]="defaultConfig['table-columns']" [counterItems]="counterItems" [counterErrors]="counterErrors" [selectedArray]="selectedArray" [isRequesting]="isRequesting"
+        [tableRole]="tableRole" overrideEditEnabled="true" [tableAvailableActions]="tableAvailableActions" [roleActions]="overrideRoleActions" (customClicked)="customActions($event)"></table-list>
     <export-file-modal #exportFileModal [showValidation]="true" [exportType]="defaultConfig['slug']" [textValidation]="'Export'" titleName='Exporting:'></export-file-modal>
   </ng-template>
   <ng-template ngSwitchDefault>
@@ -16,7 +17,7 @@
           <h4 style="display:inline"><i class="glyphicon glyphicon-cog text-info"></i> {{ editmode | uppercase}}</h4>
           <div class="pull-right" style="margin-right: 20px">
             <div style="display:inline" tooltip='Import Devices' container=body>
-                <button class="btn btn-info" type="button" (click)="importHMCDevices(sampleComponentForm.value)" [disabled]="!sampleComponentForm.valid"> <i class="glyphicon glyphicon-save"></i></button>
+                <button class="btn btn-primary" type="button" (click)="importHMCDevices(sampleComponentForm.value)" [disabled]="!sampleComponentForm.valid"> <i class="glyphicon glyphicon-import"></i></button>
             </div>
             <div style="display:inline" tooltip='Test Connection' container=body>
                 <button class="btn btn-info" type="button" (click)="testHMCServerConnection(sampleComponentForm.value)" [disabled]="!sampleComponentForm.valid"> <i class="glyphicon glyphicon-flash"></i></button>

--- a/src/app/hmcserver/hmcserver.data.ts
+++ b/src/app/hmcserver/hmcserver.data.ts
@@ -20,5 +20,6 @@ export const HMCServerComponentConfig: any =
     {'name':'export', 'type':'icon', 'icon' : 'glyphicon glyphicon-download-alt text-default', 'tooltip': 'Export item'},
     {'name':'view', 'type':'icon', 'icon' : 'glyphicon glyphicon-eye-open text-success', 'tooltip': 'View item'},
     {'name':'edit', 'type':'icon', 'icon' : 'glyphicon glyphicon-edit text-warning', 'tooltip': 'Edit item'},
-    {'name':'remove', 'type':'icon', 'icon' : 'glyphicon glyphicon glyphicon-remove text-danger', 'tooltip': 'Remove item'}
+    {'name':'remove', 'type':'icon', 'icon' : 'glyphicon glyphicon glyphicon-remove text-danger', 'tooltip': 'Remove item'},
+    {'name':'importHMCDevices', 'type':'icon', 'icon' : 'glyphicon glyphicon-import text-info', 'tooltip': 'Import Devices'},
   ]

--- a/src/app/hmcserver/hmcserver.service.ts
+++ b/src/app/hmcserver/hmcserver.service.ts
@@ -34,8 +34,8 @@ export class HMCServerService {
 
     }
 
-    editHMCServerItem(dev, id) {
-        return this.http.put('/api/cfg/hmcserver/'+id,JSON.stringify(dev,this.jsonParser))
+    editHMCServerItem(dev, id, hideAlert?) {
+        return this.http.put('/api/cfg/hmcserver/'+id,JSON.stringify(dev,this.jsonParser),null,hideAlert)
         .map( (responseData) => responseData.json());
     }
 
@@ -73,9 +73,9 @@ export class HMCServerService {
       });
     };
 
-    deleteHMCServerItem(id : string) {
+    deleteHMCServerItem(id : string, hideAlert?) {
         // return an observable
-        return this.http.delete('/api/cfg/hmcserver/'+id)
+        return this.http.delete('/api/cfg/hmcserver/'+id, null, hideAlert)
         .map( (responseData) =>
          responseData.json()
         );
@@ -86,7 +86,8 @@ export class HMCServerService {
         return this.http.post('/api/cfg/hmcserver/ping/',JSON.stringify(influxserver,this.jsonParser), null, hideAlert)
         .map((responseData) => responseData.json());
       };
-      importHMCDevices(influxserver,hideAlert?) {
+
+    importHMCDevices(influxserver,hideAlert?) {
         // return an observable
         return this.http.post('/api/cfg/hmcserver/import/',JSON.stringify(influxserver,this.jsonParser), null, hideAlert)
         .map((responseData) => responseData.json());

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,4 +1,4 @@
-<div #blocker></div>
+<div #blocker style="position: absolute; top: 50%;"></div>
 <ng-container *ngIf="userIn === true">
   <about-modal #aboutModal [showValidation]="true" titleName='About'></about-modal>
   <res-navbar [version]="version" (showModal)="showAboutModal()" (toogleMenu)="changeModeMenu()" (logout)="logout()" (link)="link('https://github.com/adejoux/pSeriesCollector/wiki')">

--- a/src/app/influxserver/influxservercfg.component.ts
+++ b/src/app/influxserver/influxservercfg.component.ts
@@ -280,7 +280,7 @@ export class InfluxServerCfgComponent {
           r = confirm("Changing Influx Server ID from " + this.oldID + " to " + this.influxserverForm.value.ID + ". Proceed?");
         }
         if (r == true) {
-          this.influxServerService.editInfluxServer(this.influxserverForm.value, this.oldID, true)
+          this.influxServerService.editInfluxServer(this.influxserverForm.value, this.oldID)
             .subscribe(data => { console.log(data) },
             err => console.error(err),
             () => { this.editmode = "list"; this.reloadData() }
@@ -288,7 +288,7 @@ export class InfluxServerCfgComponent {
         }
       }
     } else {
-      return this.influxServerService.editInfluxServer(component, component.ID)
+      return this.influxServerService.editInfluxServer(component, component.ID, true)
       .do(
         (test) =>  { this.counterItems++ },
         (err) => { this.counterErrors.push({'ID': component['ID'], 'error' : err['_body']})}

--- a/src/app/runtime/runtime.component.ts
+++ b/src/app/runtime/runtime.component.ts
@@ -432,7 +432,7 @@ export class RuntimeComponent implements OnDestroy {
       );
   }
 
-  forceDevCScan(id) {
+  forceDevScan(id) {
     console.log("ID,event", id, event);
     this.runtimeService.forceDevScan(id)
       .subscribe(


### PR DESCRIPTION
## Features
- Added new AvailableTableActions on all components
- Added new types on TableActions - single-multiedit and password input field

![image](https://user-images.githubusercontent.com/13196237/37224251-34cf1ede-23d3-11e8-94c4-e4482d6850ef.png)

- Enhanced BlockUI style

![image](https://user-images.githubusercontent.com/13196237/37224212-1563e160-23d3-11e8-94ac-2a51f8bacddd.png)

- Added import device button and user confirmation on HMCServer table to retrieve all devices

![image](https://user-images.githubusercontent.com/13196237/37224332-68fbbb90-23d3-11e8-993e-14bf37f984c8.png)


- Added BlockUI on HMCServer component to block the UI while devices are being imported

![image](https://user-images.githubusercontent.com/13196237/37224297-5344ce18-23d3-11e8-8e9e-1c93d38d226c.png)


## Fixes
- Fixed LF format on table-actions
- Fixed forceDevScan function declaration on Runtime Component
- Fixed hideAlert property on HTTPRequest on recursive/single actions on all components