### PR TITLE
Try fix for locked db message, fix #23. Added some UI enhancements

### DIFF
--- a/pkg/config/database.go
+++ b/pkg/config/database.go
@@ -45,7 +45,7 @@ func (dbc *DatabaseCfg) InitDB() {
 	switch dbc.Type {
 	case "sqlite3":
 		dbtype = "sqlite3"
-		datasource = dataDir + "/" + dbc.Name + ".db"
+		datasource = dataDir + "/" + dbc.Name + ".db?cache=shared&mode=rwc"
 	case "mysql":
 		dbtype = "mysql"
 		protocol := "tcp"

--- a/src/app/common/table-available-actions.ts
+++ b/src/app/common/table-available-actions.ts
@@ -194,9 +194,15 @@ export class AvailableTableActions {
                 ]
               },
               {
+                'title': 'NmonFilePath', 'type': 'input', 'options':
+                  new FormGroup({
+                    formControl: new FormControl('')
+                  })
+              },
+              {
                 'title': 'NmonFreq', 'type': 'input', 'options':
                   new FormGroup({
-                    formControl: new FormControl('', Validators.compose([Validators.required, ValidationService.uintegerNotZeroValidator]))
+                    formControl: new FormControl('',ValidationService.uintegerNotZeroValidator)
                   })
               },
               {
@@ -206,13 +212,13 @@ export class AvailableTableActions {
               {
                 'title': 'NmonSSHUser', 'type': 'input', 'options':
                   new FormGroup({
-                    formControl: new FormControl('', Validators.required)
+                    formControl: new FormControl('')
                   })
               },
               {
                 'title': 'NmonSSHKey', 'type': 'input-password', 'options':
                   new FormGroup({
-                    formControl: new FormControl('', Validators.required)
+                    formControl: new FormControl('')
                   })
               },
               {

--- a/src/app/hmcserver/hmcserver.component.ts
+++ b/src/app/hmcserver/hmcserver.component.ts
@@ -102,7 +102,7 @@ export class HMCServerComponent implements OnInit {
 
   importHMCDevices(data:any) {
     var r = true;
-    r = confirm("Import all Devices from " + data.ID+". This will override all defined devices. Proceed?");
+    r = confirm("Import all Devices from " + data.ID+". This will update all defined devices. Proceed?");
     if (r == true) {
       this._blocker.start(this.container, "Importing all Devices from "+ data.ID +". Please wait...");
       this.hmcserverService.importHMCDevices(data, true)

--- a/src/app/runtime/runtime.data.ts
+++ b/src/app/runtime/runtime.data.ts
@@ -5,6 +5,7 @@ export const RuntimeComponentConfig: any =
       { title: 'ID', name: 'ID' },
       { title: 'TagMap', name: 'TagMap', tooltip: 'Num Measurements configured' },
       { title: 'Type', name: 'Type', tooltip: 'Type of device polling method' },
+      { title: 'Metr.Sent', name: 'Counter0', tooltip: 'MetricSent all values had been sent' },
       { title: 'Metr.Errs', name: 'Counter1', tooltip: 'Metric Errors: number of metrics (taken as fields) with errors for all measurements' },
       { title: 'Meas.Errs', name: 'Counter3', tooltip: 'MeasurementSentErrors: number of measuremenets  formatted with errors ' },
       { title: 'G.Time', name: 'Counter5', tooltip: 'CycleGatherDuration time: elapsed time taken to get all measurement info', transform: 'elapsedseconds' },


### PR DESCRIPTION
## Fixes
- Try fix for the locked db message. Fixes #23 

## Enhancements
- Added  new column on Runtime to show the metrics sent. It will be zero if no new data is written into the nmon file
- Removed unnecessary "Required" property in devices when the user was using the multiedit option
- Added new option on multi edit to change the nmon file path
- Changed the message given by the user when trying to import devices from the HMC