### PR TITLE
Fix no reader when tryied to read empty file, fixed import when some request answers with err 500, normalized maxSize according to doc

### DIFF
--- a/pkg/agent/devices/nmon/import.go
+++ b/pkg/agent/devices/nmon/import.go
@@ -48,6 +48,8 @@ func (d *Server) ImportData(points *pointarray.PointArray) error {
 		pos, err := d.NmonFile.InitSectionDefs()
 		if err != nil {
 			d.Errorf("ImportData: Error on Section Initializations after reopen file :%s ", err)
+			d.Errorf("ImportData: New file is not open. Reseting file on next interval")
+			d.NmonFile = nil
 			return err
 		}
 

--- a/pkg/data/hmcpcm/session.go
+++ b/pkg/data/hmcpcm/session.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"encoding/xml"
-	//	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -135,7 +134,8 @@ func (s *Session) httpGet(link string) ([]byte, error) {
 		return nil, readErr
 	}
 	if response.StatusCode != 200 {
-		s.Errorf("Error getting LPAR informations. status code: %d", response.StatusCode)
+		s.Errorf("Error getting LPAR informations. status code: %d. URL: %s", response.StatusCode, link)
+		return nil, fmt.Errorf("Error getting LPAR information %s", link)
 	}
 	return contents, nil
 }

--- a/pkg/data/rfile/sftp.go
+++ b/pkg/data/rfile/sftp.go
@@ -13,7 +13,7 @@ import (
 	"golang.org/x/crypto/ssh/agent"
 )
 
-const size = 64000
+const size = 32768
 
 //SSHConfig contains SSH parameters
 type SSHConfig struct {


### PR DESCRIPTION
### Fix

- Fix no reader when trying to read empty or non file. Fix #25 
- Fix no import if some http request returns some error
- Normalise `maxSize` packets according to sftp package. This is a try to solve #20 